### PR TITLE
Refactor: move class-based theme styles to style.css

### DIFF
--- a/styles/dark.css
+++ b/styles/dark.css
@@ -14,14 +14,6 @@
   display: block;
 }
 
-.theme-dark .header__theme-menu-button_type_dark {
-  border-color: var(--border-color, #ff0070);
-}
-
-.theme-dark .header__theme-menu-button_type_light {
-  border: none;
-}
-
 .theme-dark .decorated-zone::before {
   background-image: url("../images/Rectangle77.png");
 }

--- a/styles/light.css
+++ b/styles/light.css
@@ -10,14 +10,6 @@
   --section-title-color: #353430;
 }
 
-.theme-light .header__theme-menu-button_type_light {
-  border-color: var(--border-color, #353430);
-}
-
-.theme-light .header__theme-menu-button_type_dark {
-  border: none;
-}
-
 .theme-light .header__rec-label {
   display: none;
 }
@@ -43,14 +35,6 @@
     --section-title-color: #353430;
   }
 
-  .header__theme-menu-button_type_light {
-    border-color: var(--border-color, #353430);
-  }
-
-  .header__theme-menu-button_type_dark {
-    border: none;
-  }
-
   .header__rec-label {
     display: none;
   }
@@ -61,13 +45,5 @@
 
   .decorated-zone::after {
     background-image: url("../images/Rectangle_light79.png");
-  }
-
-  .header__theme-menu-button {
-    border: 1px solid transparent;
-  }
-
-  .header__theme-menu-button_active {
-    border: 1px solid var(--border-color, #353430);
   }
 }

--- a/styles/style.css
+++ b/styles/style.css
@@ -87,6 +87,30 @@
   cursor: pointer;
 }
 
+.theme-light .header__theme-menu-button_type_dark {
+  border: none;
+}
+
+.header__theme-menu-button_type_light {
+  border-color: var(--border-color, #353430);
+}
+
+.header__theme-menu-button_type_dark {
+  border: none;
+}
+
+.header__theme-menu-button {
+  border: 1px solid transparent;
+}
+
+.theme-dark .header__theme-menu-button_type_dark {
+  border-color: var(--border-color, #ff0070);
+}
+
+.theme-dark .header__theme-menu-button_type_light {
+  border: none;
+}
+
 .header__theme-menu-button_active {
   border: 1px solid;
   border-color: var(--border-color, #ff0070);


### PR DESCRIPTION
Moved all styles related to .theme-light and .theme-dark classes from light.css and dark.css to style.css, following Practicum review requirements. Ensures proper separation of auto-mode (media query) vs class-based theme switching.